### PR TITLE
Funcion para listar comisiones pendientes y ejecutar pagadas

### DIFF
--- a/src/DAO/dao_comisiones.java
+++ b/src/DAO/dao_comisiones.java
@@ -74,4 +74,31 @@ public class dao_comisiones implements int_Comision {
         return s.getcomisiones_Especial(c, fecha, referencia);
     }
 
+    /**
+     * Obtiene las comisiones pendientes de pagar a los agentes, osease que
+     * status sea 1
+     *
+     * @param c conexion cpt
+     * @param nombre nombre del agente
+     * @param bd nombre de bd de cobranza
+     * @return lista de comisiones
+     */
+    @Override
+    public ArrayList<Comision> getcomisiones_toadm(Connection c, String nombre, String bd) {
+        return s.getcomisiones_toadm(c, nombre, bd);
+    }
+
+    /**
+     * Cambia el estatus de la comision a "2", esto indica que la comision ha
+     * sido entregada al agente
+     *
+     * @param c
+     * @param com
+     * @return
+     */
+    @Override
+    public boolean Comisionpagada(Connection c, ArrayList<Comision> arr) {
+        return s.Comisionpagada(c, arr);
+    }
+
 }

--- a/src/DAO/int_Comision.java
+++ b/src/DAO/int_Comision.java
@@ -17,9 +17,13 @@ public interface int_Comision {
 
     public ArrayList<Comision> getcomisiones(Connection c, String fecha, String referencia);
     
+    public ArrayList<Comision> getcomisiones_toadm(Connection c, String nombre, String bd);
+    
     public ArrayList<Comision> getcomisiones_Especial(Connection c, String fecha, String referencia);
 
     public boolean newcomision(Connection c, ArrayList<Comision> arr);
     
     public boolean cancelacomision(Connection c, ArrayList<Comision> arr);
+    
+    public boolean Comisionpagada(Connection c, ArrayList<Comision> arr);
 }

--- a/src/Modelo/Comision.java
+++ b/src/Modelo/Comision.java
@@ -9,11 +9,28 @@ package Modelo;
  *
  * @author GATEWAY1-
  */
-public class Comision {
+public class Comision implements java.io.Serializable{
 
-    private int id_cargo, dias, id_agente, porcentaje;
+    private int id_cargo, dias, id_agente, porcentaje, id_comision;
     private String moneda, fecha, usuario, estatus, serie, referencia, foliopago;
     private double importe, comision, tipocambio;
+    private String nagente;
+
+    public String getNagente() {
+        return nagente;
+    }
+
+    public void setNagente(String nagente) {
+        this.nagente = nagente;
+    }
+
+    public int getId_comision() {
+        return id_comision;
+    }
+
+    public void setId_comision(int id_comision) {
+        this.id_comision = id_comision;
+    }
 
     public int getPorcentaje() {
         return porcentaje;

--- a/src/Persistencia/sql_comisiones.java
+++ b/src/Persistencia/sql_comisiones.java
@@ -161,4 +161,62 @@ public class sql_comisiones {
         return arr;
     }
 
+    public ArrayList<Comision> getcomisiones_toadm(Connection c, String nombre, String bd) {
+        ArrayList<Comision> arr = new ArrayList<>();
+        try {
+            String sql = "select id_comision,c.id_agente,referencia,dias,c.comision,"
+                    + "convert(date,fecha) as fecha, importe, tipocambio,c.estatus,"
+                    + "porcentaje,serie,a.nombre\n"
+                    + " from comisiones c\n"
+                    + " join " + bd + ".dbo.agente a on c.id_agente=a.id_agente\n"
+                    + " where a.nombre like '%" + nombre + "%' and c.estatus='1'";
+//            System.out.println(sql);
+            PreparedStatement st;
+            ResultSet rs;
+            st = c.prepareStatement(sql);
+            rs = st.executeQuery();
+            while (rs.next()) {
+                Comision s = new Comision();
+                s.setId_comision(rs.getInt("id_comision"));
+                s.setReferencia(rs.getString("referencia"));
+                s.setImporte(rs.getDouble("importe"));
+                s.setDias(rs.getInt("dias"));
+                s.setComision(rs.getDouble("comision"));
+                s.setFecha(rs.getString("fecha"));
+                s.setPorcentaje(rs.getInt("porcentaje"));
+                s.setNagente(rs.getString("nombre"));
+                s.setEstatus(rs.getString("estatus"));
+                arr.add(s);
+            }
+            rs.close();
+            st.close();
+        } catch (SQLException ex) {
+            Logger.getLogger(sql_comisiones.class.getName()).log(Level.SEVERE, null, ex);
+        }
+        return arr;
+    }
+
+    public boolean Comisionpagada(Connection c, ArrayList<Comision> arr) {
+        try {
+            PreparedStatement st=null;
+            c.setAutoCommit(false);
+            for (Comision arr2 : arr) {
+                String sql = "update Comisiones set estatus='2' where id_comision=?";
+                st = c.prepareStatement(sql);
+                st.setInt(1, arr2.getId_comision());
+                st.executeUpdate();
+            }
+            st.close();
+            c.commit();
+            return true;
+        } catch (SQLException ex) {
+            try {
+                c.rollback();
+                Logger.getLogger(sql_comisiones.class.getName()).log(Level.SEVERE, null, ex);
+            } catch (SQLException ex1) {
+                Logger.getLogger(sql_comisiones.class.getName()).log(Level.SEVERE, null, ex1);
+            }
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
*feat, (sqlcomisiones, int_comision, dao_comisiones), Se ha agreagado 2 funciones para la gestion de comisiones, la primera para el  despliegue de comisiones pendientes de acuerdo a la busqueda y la  segunda para cambiar el estatus a "pagado" y no repetir valores innecesarios
*feat, (Comision), Se ha agregado el campo "id_comision" y "Nagente", el primero es el registro PK de la tabla y el segundo para mostrar al usuario a que agente pertenece la comision